### PR TITLE
fix: coverButton check

### DIFF
--- a/oldCoverClick/oldCoverClick.js
+++ b/oldCoverClick/oldCoverClick.js
@@ -1,18 +1,18 @@
 (function oldCoverClick() {
-    // Ensure the UI is fully loaded, to prevent issues later.
-    if (!(Spicetify?.Player?.data && Spicetify?.Menu && Spicetify?.LocalStorage && Spicetify?.Platform)) {
-        setTimeout(oldCoverClick, 1000);
-        return;
-    }
+    // Get the <button> element that the cover uses
+	const coverButton = document.querySelector( '.HD9s7U5E1RLSWKpXmrqx, .Root__now-playing-bar [data-testid="cover-art-button"]' );
+    
+	// Ensure the UI is fully loaded, to prevent issues later.
+	if ( !coverButton || !( Spicetify?.Player?.data && Spicetify?.Menu && Spicetify?.LocalStorage && Spicetify?.Platform ) ) {
+		setTimeout( oldCoverClick, 1000 );
+		return;
+	}
 
     // Hook the cover on startup
     hookCoverButton();
 
     // Updates (or creates) the click event of the cover button
     function hookCoverButton() {
-        // Get the <button> element that the cover uses
-        let coverButton = document.querySelector(".HD9s7U5E1RLSWKpXmrqx");
-
         // Navigates to the currently playing song on click
         coverButton.addEventListener("click", async (e) => {
             // Prevent the Now Playing panel from appearing


### PR DESCRIPTION
Kept getting an error when `hookCoverButton` would try to add the event listener to the `coverButton`  - due to it being null.

I just moved the definition for `coverButton` so that the script won't continue unless the element's found.

_Also added a more general "backup selector" in case Spotify changes the class with an update or something. It doesn't break anything and it's not needed right now, it's just a fallback._

![Screenshot 2024-09-14 232239](https://github.com/user-attachments/assets/7b3c5f90-7cad-43e6-a937-18faf295113e)